### PR TITLE
Fixes and Improvements

### DIFF
--- a/sim_models_internal/primitives_mapping/BRAM/rs_tdp36k_post_pnr_mapping.v
+++ b/sim_models_internal/primitives_mapping/BRAM/rs_tdp36k_post_pnr_mapping.v
@@ -92,7 +92,7 @@ module RS_TDP36K #(
                     end
                 end
 
-                localparam data_width_width = 
+                localparam data_width_write = 
                     (WMODE_A1_i == 3'b110) ? 6'b100100 :
                     (WMODE_A1_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam data_width_read = 
@@ -119,7 +119,7 @@ module RS_TDP36K #(
                 end
 
                 FIFO36K #(
-                    .DATA_WRITE_WIDTH(data_width_width),
+                    .DATA_WRITE_WIDTH(data_width_write),
                     .DATA_READ_WIDTH(data_width_read),
                     .FIFO_TYPE(fifo_type),
                     .PROG_FULL_THRESH(UPAF1_i),
@@ -338,9 +338,9 @@ module RS_TDP36K #(
                     end
                 end
 
-                localparam data_width_width1 = (WMODE_A1_i == 3'b010) ? 5'b10010 : 4'b1001;
+                localparam data_width_write1 = (WMODE_A1_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam data_width_read1 =  (RMODE_B1_i == 3'b010) ? 5'b10010 : 4'b1001;
-                localparam data_width_width2 = (WMODE_A2_i == 3'b010) ? 5'b10010 : 4'b1001;
+                localparam data_width_write2 = (WMODE_A2_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam data_width_read2 =  (RMODE_B2_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam fifo_type1   = (SYNC_FIFO1_i == 1'b1) ? "SYNCHRONOUS" : "ASYNCHRONOUS";
                 localparam fifo_type2   = (SYNC_FIFO2_i == 1'b1) ? "SYNCHRONOUS" : "ASYNCHRONOUS"; 
@@ -373,12 +373,12 @@ module RS_TDP36K #(
                 end
 
                 FIFO18KX2 #(
-                    .DATA_WRITE_WIDTH1(data_width_width1),
+                    .DATA_WRITE_WIDTH1(data_width_write1),
                     .DATA_READ_WIDTH1(data_width_read1),
                     .FIFO_TYPE1(fifo_type1),
                     .PROG_FULL_THRESH1(UPAF1_i),
                     .PROG_EMPTY_THRESH1(UPAE1_i),
-                    .DATA_WRITE_WIDTH2(data_width_width2),
+                    .DATA_WRITE_WIDTH2(data_width_write2),
                     .DATA_READ_WIDTH2(data_width_read2),
                     .FIFO_TYPE2(fifo_type2),
                     .PROG_FULL_THRESH2(UPAF2_i),
@@ -732,7 +732,7 @@ module RS_TDP36K #(
                     end
                 end
 
-                localparam data_width_width1 = (WMODE_A1_i == 3'b010) ? 5'b10010 : 4'b1001;
+                localparam data_width_write1 = (WMODE_A1_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam data_width_read1 =  (RMODE_B1_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam fifo_type1   = (SYNC_FIFO1_i == 1'b1) ? "SYNCHRONOUS" : "ASYNCHRONOUS";
 
@@ -751,7 +751,7 @@ module RS_TDP36K #(
                 end
 
                 FIFO18KX2 #(
-                    .DATA_WRITE_WIDTH1(data_width_width1),
+                    .DATA_WRITE_WIDTH1(data_width_write1),
                     .DATA_READ_WIDTH1(data_width_read1),
                     .FIFO_TYPE1(fifo_type1),
                     .PROG_FULL_THRESH1(UPAF1_i),
@@ -1055,7 +1055,7 @@ module RS_TDP36K #(
                     end
                 end
 
-                localparam data_width_width2 = (WMODE_A2_i == 3'b010) ? 5'b10010 : 4'b1001;
+                localparam data_width_write2 = (WMODE_A2_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam data_width_read2 =  (RMODE_B2_i == 3'b010) ? 5'b10010 : 4'b1001;
                 localparam fifo_type2   = (SYNC_FIFO2_i == 1'b1) ? "SYNCHRONOUS" : "ASYNCHRONOUS"; 
                 
@@ -1073,7 +1073,7 @@ module RS_TDP36K #(
                 end
 
                 FIFO18KX2 #(
-                    .DATA_WRITE_WIDTH2(data_width_width2),
+                    .DATA_WRITE_WIDTH2(data_width_write2),
                     .DATA_READ_WIDTH2(data_width_read2),
                     .FIFO_TYPE2(fifo_type2),
                     .PROG_FULL_THRESH2(UPAF2_i),

--- a/sim_models_internal/primitives_mapping/DSP/dsp19x2_to_rs_dsp_XX_mapping.v
+++ b/sim_models_internal/primitives_mapping/DSP/dsp19x2_to_rs_dsp_XX_mapping.v
@@ -74,7 +74,7 @@ module DSP19X2 #(
     generate
         if (output_select == 3'b000 && input_reg == 1'b1) begin
             RS_DSP_MULT_REGIN # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULT_REGIN (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -88,7 +88,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b001 && input_reg == 1'b0) begin
             RS_DSP_MULT_REGOUT # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULT_REGOUT (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -102,7 +102,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b001 && input_reg == 1'b1) begin
             RS_DSP_MULT_REGIN_REGOUT # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULT_REGIN_REGOUT (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -116,7 +116,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b010 && input_reg == 1'b0) begin
             RS_DSP_MULTADD # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTADD (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -137,7 +137,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b010 && input_reg == 1'b1) begin
             RS_DSP_MULTADD_REGIN # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTADD_REGIN (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -158,7 +158,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b011 && input_reg == 1'b0) begin
             RS_DSP_MULTADD_REGOUT # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTADD_REGOUT (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -179,7 +179,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b011 && input_reg == 1'b1) begin
             RS_DSP_MULTADD_REGIN_REGOUT # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTADD_REGIN_REGOUT (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -200,7 +200,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b100 && input_reg == 1'b0) begin
             RS_DSP_MULTACC # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTACC (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -219,7 +219,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b100 && input_reg == 1'b1) begin
             RS_DSP_MULTACC_REGIN # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTACC_REGIN (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -238,7 +238,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b101 && input_reg == 1'b0) begin
             RS_DSP_MULTACC_REGOUT # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTACC_REGOUT (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -257,7 +257,7 @@ module DSP19X2 #(
         end
         else if (output_select == 3'b101 && input_reg == 1'b1) begin
             RS_DSP_MULTACC_REGIN_REGOUT # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULTACC_REGIN_REGOUT (
                 .a({A1, A2}), 
                 .b({B1, B2}), 
@@ -276,7 +276,7 @@ module DSP19X2 #(
         end
         else begin
             RS_DSP_MULT # (
-                .MODE_BITS({{COEFF1_0, COEFF2_0}, {COEFF1_1, COEFF2_1}, {COEFF1_2, COEFF2_2}, {COEFF1_3, COEFF2_3}, 4'bxxxx, 1'b1})
+                .MODE_BITS({{COEFF1_0[9:0], COEFF2_0[9:0]}, {COEFF1_1[9:0], COEFF2_1[9:0]}, {COEFF1_2[9:0], COEFF2_2[9:0]}, {COEFF1_3[9:0], COEFF2_3[9:0]}, 4'bxxxx, 1'b1})
             ) RS_DSP_MULT (
                 .a({A1, A2}), 
                 .b({B1, B2}), 

--- a/sim_models_internal/primitives_mapping/DSP/dsp38_to_rs_dsp_XX_mapping.v
+++ b/sim_models_internal/primitives_mapping/DSP/dsp38_to_rs_dsp_XX_mapping.v
@@ -66,7 +66,7 @@ module DSP38 #(
     generate
         if (output_select == 3'b000 && input_reg == 1'b1) begin
             RS_DSP_MULT_REGIN # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULT_REGIN (
                 .a(A), 
                 .b(B), 
@@ -80,7 +80,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b001 && input_reg == 1'b0) begin
             RS_DSP_MULT_REGOUT # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULT_REGOUT (
                 .a(A), 
                 .b(B), 
@@ -94,7 +94,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b001 && input_reg == 1'b1) begin
             RS_DSP_MULT_REGIN_REGOUT # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULT_REGIN_REGOUT (
                 .a(A), 
                 .b(B), 
@@ -108,7 +108,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b010 && input_reg == 1'b0) begin
             RS_DSP_MULTADD # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTADD (
                 .a(A), 
                 .b(B), 
@@ -129,7 +129,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b010 && input_reg == 1'b1) begin
             RS_DSP_MULTADD_REGIN # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTADD_REGIN (
                 .a(A), 
                 .b(B), 
@@ -150,7 +150,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b011 && input_reg == 1'b0) begin
             RS_DSP_MULTADD_REGOUT # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTADD_REGOUT (
                 .a(A), 
                 .b(B), 
@@ -171,7 +171,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b011 && input_reg == 1'b1) begin
             RS_DSP_MULTADD_REGIN_REGOUT # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTADD_REGIN_REGOUT (
                 .a(A), 
                 .b(B), 
@@ -192,7 +192,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b100 && input_reg == 1'b0) begin
             RS_DSP_MULTACC # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTACC (
                 .a(A), 
                 .b(B), 
@@ -211,7 +211,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b100 && input_reg == 1'b1) begin
             RS_DSP_MULTACC_REGIN # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTACC_REGIN (
                 .a(A), 
                 .b(B), 
@@ -230,7 +230,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b101 && input_reg == 1'b0) begin
             RS_DSP_MULTACC_REGOUT # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTACC_REGOUT (
                 .a(A), 
                 .b(B), 
@@ -249,7 +249,7 @@ module DSP38 #(
         end
         else if (output_select == 3'b101 && input_reg == 1'b1) begin
             RS_DSP_MULTACC_REGIN_REGOUT # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULTACC_REGIN_REGOUT (
                 .a(A), 
                 .b(B), 
@@ -268,7 +268,7 @@ module DSP38 #(
         end
         else begin
             RS_DSP_MULT # (
-                .MODE_BITS({COEFF_0, COEFF_1, COEFF_2, COEFF_3, 4'bxxxx, 1'b0})
+                .MODE_BITS({COEFF_0[19:0], COEFF_1[19:0], COEFF_2[19:0], COEFF_3[19:0], 4'bxxxx, 1'b0})
             ) RS_DSP_MULT (
                 .a(A), 
                 .b(B), 

--- a/sim_models_internal/primitives_mapping/FIFO/fifo18kx2_to_rs_tdp_36k_mapping.v
+++ b/sim_models_internal/primitives_mapping/FIFO/fifo18kx2_to_rs_tdp_36k_mapping.v
@@ -54,12 +54,12 @@ module FIFO18KX2 #(
 );
 
 initial begin
-    if ((DATA_WRITE_WIDTH1 < 1'b1) || (DATA_WRITE_WIDTH1 > 5'b10010)) begin
-       $display("FIFO18KX2 instance %m DATA_WRITE_WIDTH1 set to incorrect value, %d.  Values must be between 1 and 18.", DATA_WRITE_WIDTH1);
+    if (!(DATA_WRITE_WIDTH1 == 5'b10010) || (DATA_WRITE_WIDTH1 == 4'b1001)) begin
+       $display("FIFO18KX2 instance %m DATA_WRITE_WIDTH1 set to incorrect value, %d.  Values must be either 9 or 18.", DATA_WRITE_WIDTH1);
     #1 $stop;
     end
-    if ((DATA_READ_WIDTH1 < 1'b1) || (DATA_READ_WIDTH1 > 5'b10010)) begin
-       $display("FIFO18KX2 instance %m DATA_READ_WIDTH1 set to incorrect value, %d.  Values must be between 1 and 18.", DATA_READ_WIDTH1);
+    if (!(DATA_READ_WIDTH1 == 5'b10010) || (DATA_READ_WIDTH1 == 4'b1001)) begin
+       $display("FIFO18KX2 instance %m DATA_READ_WIDTH1 set to incorrect value, %d.  Values must be either 9 or 18.", DATA_READ_WIDTH1);
     #1 $stop;
     end
     case(FIFO_TYPE1)
@@ -71,12 +71,12 @@ initial begin
       end
     endcase
 
-    if ((DATA_WRITE_WIDTH2 < 1'b1) || (DATA_WRITE_WIDTH2 > 5'b10010)) begin
-       $display("FIFO18KX2 instance %m DATA_WRITE_WIDTH2 set to incorrect value, %d.  Values must be between 1 and 18.", DATA_WRITE_WIDTH2);
+    if (!(DATA_WRITE_WIDTH2 == 5'b10010) || (DATA_WRITE_WIDTH2 == 4'b1001)) begin
+       $display("FIFO18KX2 instance %m DATA_WRITE_WIDTH2 set to incorrect value, %d.  Values must be either 9 or 18.", DATA_WRITE_WIDTH2);
     #1 $stop;
     end
-    if ((DATA_READ_WIDTH2 < 1'b1) || (DATA_READ_WIDTH2 > 5'b10010)) begin
-       $display("FIFO18KX2 instance %m DATA_READ_WIDTH2 set to incorrect value, %d.  Values must be between 1 and 18.", DATA_READ_WIDTH2);
+    if (!(DATA_READ_WIDTH2 == 5'b10010) || (DATA_READ_WIDTH2 == 4'b1001)) begin
+       $display("FIFO18KX2 instance %m DATA_READ_WIDTH2 set to incorrect value, %d.  Values must be either 9 or 18.", DATA_READ_WIDTH2);
     #1 $stop;
     end
     case(FIFO_TYPE2)

--- a/sim_models_internal/primitives_mapping/FIFO/fifo18kx2_to_rs_tdp_36k_mapping.v
+++ b/sim_models_internal/primitives_mapping/FIFO/fifo18kx2_to_rs_tdp_36k_mapping.v
@@ -5,14 +5,14 @@
 // --------------------------------------------------------------------------
 
 module FIFO18KX2 #(
-    parameter DATA_WRITE_WIDTH1 = 5'b10010,        // Write Data Width of FIFO1 from 1, 2, 4, 9, 18
-    parameter DATA_READ_WIDTH1 = 5'b10010,         // Read Data Width of FIFO1 from 1, 2, 4, 9, 18
+    parameter DATA_WRITE_WIDTH1 = 5'b10010,        // Write Data Width of FIFO1: 9 and 18 for translation in hardware
+    parameter DATA_READ_WIDTH1 = 5'b10010,         // Read Data Width of FIFO1: 9 and 18 for translation in hardware
     parameter FIFO_TYPE1 = "SYNCHRONOUS",       // Synchronous or Asynchronous FIFO1     
     parameter PROG_EMPTY_THRESH1 = 11'b00000000100,     // Threshold indicating that the FIFO1 buffer is considered Empty
     parameter PROG_FULL_THRESH1 = 11'b10011111010,      // Threshold indicating that the FIFO1 buffer is considered Full
     
-    parameter DATA_WRITE_WIDTH2 = 5'b10010,        // Write Data Width of FIFO2 from 1, 2, 4, 9, 18
-    parameter DATA_READ_WIDTH2 = 5'b10010,         // Read Data Width of FIFO1 from 1, 2, 4, 9, 18
+    parameter DATA_WRITE_WIDTH2 = 5'b10010,        // Write Data Width of FIFO2: 9 and 18 for transation in hardware
+    parameter DATA_READ_WIDTH2 = 5'b10010,         // Read Data Width of FIFO1: 9 and 18 for transation in hardware
     parameter FIFO_TYPE2 = "SYNCHRONOUS",       // Synchronous or Asynchronous FIFO2    
     parameter PROG_EMPTY_THRESH2 = 11'b00000000100,     // Threshold indicating that the FIFO2 buffer is considered Empty
     parameter PROG_FULL_THRESH2 = 11'b10011111010       // Threshold indicating that the FIFO2 buffer is considered Full
@@ -52,11 +52,6 @@ module FIFO18KX2 #(
     output wire OVERFLOW2,                      // 1-bit output: Overflow Flag 
     output wire UNDERFLOW2                      // 1-bit output: Underflow Flag
 );
-
-localparam data_width_write1 = (DATA_WRITE_WIDTH1 > 4'b1001) ? 5'b10010 : DATA_WRITE_WIDTH1;
-localparam data_width_write2 = (DATA_WRITE_WIDTH2 > 4'b1001) ? 5'b10010 : DATA_WRITE_WIDTH2;
-localparam data_width_read1 = (DATA_READ_WIDTH1 > 4'b1001) ? 5'b10010 : DATA_READ_WIDTH1;
-localparam data_width_read2 = (DATA_READ_WIDTH2 > 4'b1001) ? 5'b10010 : DATA_READ_WIDTH2;
 
 initial begin
     if ((DATA_WRITE_WIDTH1 < 1'b1) || (DATA_WRITE_WIDTH1 > 5'b10010)) begin
@@ -100,7 +95,7 @@ localparam fifo_type2   = (FIFO_TYPE2 == "SYNCHRONOUS") ? 1'b1 : 1'b0;
 
 // FIFO1
 generate
-  if (data_width_write1 == 5'b10010 && data_width_read1 == 5'b10010)
+  if (DATA_WRITE_WIDTH1 == 5'b10010 && DATA_READ_WIDTH1 == 5'b10010)
       begin
           RS_TDP36K #(
               // ----------------------------------------------------------Appending 12th bit as dont care bit
@@ -120,7 +115,7 @@ generate
           );
       end
 
-  else if (data_width_write1 == 4'b1001 && data_width_read1 == 4'b1001)
+  else if (DATA_WRITE_WIDTH1 == 4'b1001 && DATA_READ_WIDTH1 == 4'b1001)
       begin
           wire [17:0] rd_data1;
           assign RD_DATA1 = {rd_data1[16], rd_data1[7:0]};
@@ -141,7 +136,7 @@ generate
               .CLK_B2(RD_CLK1)
           );
       end
-  else if (data_width_write1 == 5'b10010 && data_width_read1 == 4'b1001)
+  else if (DATA_WRITE_WIDTH1 == 5'b10010 && DATA_READ_WIDTH1 == 4'b1001)
       begin
           wire [17:0] rd_data1;
           assign RD_DATA1 = {rd_data1[16], rd_data1[7:0]};
@@ -188,7 +183,7 @@ endgenerate
 
 // FIFO2
 generate
-  if (data_width_write2 == 5'b10010 && data_width_read2 == 5'b10010)
+  if (DATA_WRITE_WIDTH2 == 5'b10010 && DATA_READ_WIDTH2 == 5'b10010)
       begin
           RS_TDP36K #(
               // ----------------------------------------------------------Appending 12th bit as dont care bit
@@ -208,7 +203,7 @@ generate
           );
       end
 
-  else if (data_width_write2 == 4'b1001 && data_width_read2 == 4'b1001)
+  else if (DATA_WRITE_WIDTH2 == 4'b1001 && DATA_READ_WIDTH2 == 4'b1001)
       begin
           wire [17:0] rd_data2;
           assign RD_DATA2 = {rd_data2[16], rd_data2[7:0]};
@@ -229,7 +224,7 @@ generate
               .CLK_B2(RD_CLK2)
           );
       end
-  else if (data_width_write2 == 5'b10010 && data_width_read2 == 4'b1001)
+  else if (DATA_WRITE_WIDTH2 == 5'b10010 && DATA_READ_WIDTH2 == 4'b1001)
       begin
           wire [17:0] rd_data2;
           assign RD_DATA2 = {rd_data2[16], rd_data2[7:0]};

--- a/sim_models_internal/primitives_mapping/FIFO/fifo36k_to_rs_tdp_36k_mapping.v
+++ b/sim_models_internal/primitives_mapping/FIFO/fifo36k_to_rs_tdp_36k_mapping.v
@@ -30,12 +30,12 @@ module FIFO36K #(
 );
 
 initial begin
-    if ((DATA_WRITE_WIDTH < 1'b1) || (DATA_WRITE_WIDTH > 6'b100100)) begin
-       $display("FIFO36K instance %m DATA_WRITE_WIDTH set to incorrect value, %d.  Values must be between 1 and 36.", DATA_WRITE_WIDTH);
+    if (!(DATA_WRITE_WIDTH == 6'b100100) || (DATA_WRITE_WIDTH == 5'b10010) || (DATA_WRITE_WIDTH == 4'b1001)) begin
+       $display("FIFO36K instance %m DATA_WRITE_WIDTH set to incorrect value, %d.  Values must be either 9, 18 or 36.", DATA_WRITE_WIDTH);
     #1 $stop;
     end
-    if ((DATA_READ_WIDTH < 1'b1) || (DATA_READ_WIDTH > 6'b100100)) begin
-       $display("FIFO36K instance %m DATA_READ_WIDTH set to incorrect value, %d.  Values must be between 1 and 36.", DATA_READ_WIDTH);
+    if (!(DATA_READ_WIDTH == 6'b100100) || (DATA_READ_WIDTH == 5'b10010) || (DATA_READ_WIDTH == 4'b1001)) begin
+       $display("FIFO36K instance %m DATA_READ_WIDTH set to incorrect value, %d.  Values must be either 9, 18 or 36.", DATA_READ_WIDTH);
     #1 $stop;
     end
     case(FIFO_TYPE)

--- a/sim_models_internal/primitives_mapping/FIFO/fifo36k_to_rs_tdp_36k_mapping.v
+++ b/sim_models_internal/primitives_mapping/FIFO/fifo36k_to_rs_tdp_36k_mapping.v
@@ -5,11 +5,11 @@
 // --------------------------------------------------------------------------
 
 module FIFO36K #(
-    parameter   DATA_WRITE_WIDTH    = 6'b100100,               // Supported Data Width 1 - 36
-    parameter   DATA_READ_WIDTH     = 6'b100100,               // Supported Data Width 1 - 36
+    parameter   DATA_WRITE_WIDTH    = 6'b100100,           // Supported Data Width: 9, 18 and 36 for translation in hardware
+    parameter   DATA_READ_WIDTH     = 6'b100100,           // Supported Data Width: 9, 18 and 36 for translation in hardware
     parameter   FIFO_TYPE           = "SYNCHRONOUS",       // Synchronous or Asynchronous
-    parameter   PROG_FULL_THRESH    = 12'b111111111010,             // Threshold indicating that the FIFO buffer is considered Full
-    parameter   PROG_EMPTY_THRESH   = 12'b000000000100              // Threshold indicating that the FIFO buffer is considered Empty
+    parameter   PROG_FULL_THRESH    = 12'b111111111010,    // Threshold indicating that the FIFO buffer is considered Full
+    parameter   PROG_EMPTY_THRESH   = 12'b000000000100     // Threshold indicating that the FIFO buffer is considered Empty
 )
 (
     input wire  [DATA_WRITE_WIDTH-1:0] WR_DATA,            // 36-bits Data coming inside FIFO
@@ -28,15 +28,6 @@ module FIFO36K #(
     input wire  RD_CLK,                                    // 1-bit input:  Read Clock
     input wire  RESET                                      // 1-bit input:  Active Low Synchronous Reset
 );
-
-localparam data_width_width = 
-    (DATA_WRITE_WIDTH > 5'b10010) ? 6'b100100 :
-    (DATA_WRITE_WIDTH > 4'b1001)  ? 5'b10010 :
-                          DATA_WRITE_WIDTH;
-localparam data_width_read = 
-    (DATA_READ_WIDTH > 5'b10010) ? 6'b100100 :
-    (DATA_READ_WIDTH > 4'b1001)  ? 5'b10010 :
-                          DATA_READ_WIDTH;
 
 initial begin
     if ((DATA_WRITE_WIDTH < 1'b1) || (DATA_WRITE_WIDTH > 6'b100100)) begin
@@ -62,7 +53,7 @@ localparam fifo_type   = (FIFO_TYPE == "SYNCHRONOUS")     ? 1'b1      : 1'b0;
 
 // FIFO
 generate
-    if (data_width_width == 6'b100100 && data_width_read == 6'b100100)
+    if (DATA_WRITE_WIDTH == 6'b100100 && DATA_READ_WIDTH == 6'b100100)
         begin
             RS_TDP36K #(
                 .MODE_BITS({fifo_type, {4{3'b110}}, 1'b1, 1'b0, 1'b0, 1'b0, PROG_EMPTY_THRESH[11:0], PROG_FULL_THRESH[11:0], 39'b000000000000000000000000000000000000000, 1'b0})
@@ -83,7 +74,7 @@ generate
             );
         end
 
-    else if (data_width_width == 5'b10010 && data_width_read == 5'b10010)
+    else if (DATA_WRITE_WIDTH == 5'b10010 && DATA_READ_WIDTH == 5'b10010)
         begin
             RS_TDP36K #(
                 // ----------------------------------------------------------Appending 12th bit as dont care bit
@@ -103,7 +94,7 @@ generate
             );
         end
 
-    else if (data_width_width == 4'b1001 && data_width_read == 4'b1001)
+    else if (DATA_WRITE_WIDTH == 4'b1001 && DATA_READ_WIDTH == 4'b1001)
         begin
             wire [17:0] rd_data;
             assign RD_DATA = {rd_data[16], rd_data[7:0]};
@@ -124,7 +115,7 @@ generate
                 .CLK_B2(RD_CLK)
             );
         end
-    else if (data_width_width == 6'b100100 && data_width_read == 5'b10010)
+    else if (DATA_WRITE_WIDTH == 6'b100100 && DATA_READ_WIDTH == 5'b10010)
         begin
             RS_TDP36K #(
                 .MODE_BITS({fifo_type, {2{3'b010}}, {2{3'b110}}, 1'b1, 1'b0, 1'b0, 1'b0, PROG_EMPTY_THRESH[11:0], PROG_FULL_THRESH[11:0], 39'b000000000000000000000000000000000000000, 1'b0})
@@ -143,7 +134,7 @@ generate
                 .CLK_B2(RD_CLK)
             );
         end
-    else if (data_width_width == 6'b100100 && data_width_read == 4'b1001)
+    else if (DATA_WRITE_WIDTH == 6'b100100 && DATA_READ_WIDTH == 4'b1001)
         begin
             wire [17:0] rd_data;
             assign RD_DATA = {rd_data[16], rd_data[7:0]};
@@ -164,7 +155,7 @@ generate
                 .CLK_B2(RD_CLK)
             );
         end
-    else if (data_width_width == 5'b10010 && data_width_read == 4'b1001)
+    else if (DATA_WRITE_WIDTH == 5'b10010 && DATA_READ_WIDTH == 4'b1001)
         begin
             wire [17:0] rd_data;
             assign RD_DATA = {rd_data[16], rd_data[7:0]};
@@ -185,7 +176,7 @@ generate
                 .CLK_B2(RD_CLK)
             );
         end
-    else if (data_width_width == 4'b1001 && data_width_read == 5'b10010)
+    else if (DATA_WRITE_WIDTH == 4'b1001 && DATA_READ_WIDTH == 5'b10010)
         begin
             wire [17:0] rd_data;
             assign RD_DATA = {rd_data[17], rd_data[15:8], rd_data[16], rd_data[7:0]};
@@ -206,7 +197,7 @@ generate
                 .CLK_B2(RD_CLK)
             );
         end
-    else if (data_width_width == 5'b10010 && data_width_read == 6'b100100)
+    else if (DATA_WRITE_WIDTH == 5'b10010 && DATA_READ_WIDTH == 6'b100100)
         begin
             RS_TDP36K #(
                 .MODE_BITS({fifo_type, {2{3'b110}}, {2{3'b010}}, 1'b1, 1'b0, 1'b0, 1'b0, PROG_EMPTY_THRESH[11:0], PROG_FULL_THRESH[11:0], 39'b000000000000000000000000000000000000000, 1'b0})


### PR DESCRIPTION
- Fixed the bit width of Coefficients in DSP forward translation files so no error comes in MODE_BITS configuration
- Changed the data widths from continuous to discrete in FIFO forward mapping files
- Fixed a typo in rs_tdp36k reverse mapping file from "width_width" to "write_width"
- Corrected the error message accordingly