### PR TITLE
fail_sim_1.1.5_internal_fixed

### DIFF
--- a/blackbox_models/cell_sim_blackbox.v
+++ b/blackbox_models/cell_sim_blackbox.v
@@ -272,7 +272,6 @@ module I_BUF_DS #(
   input logic I_P,
   (* iopad_external_pin *)
   input logic I_N,
-  (* iopad_external_pin *)
   input logic EN,
   output reg O
 );

--- a/specs_internal/I_BUF_DS.yaml
+++ b/specs_internal/I_BUF_DS.yaml
@@ -59,7 +59,6 @@ ports:
    EN:
      dir: input
      desc: Enable the input
-     bb_attributes: iopad_external_pin
    O:
      dir: output
      type: reg


### PR DESCRIPTION
- removed io attribute from EN pin of I_BUF_DS