### PR TITLE
Manual release 1.4.4

### DIFF
--- a/sim_models/verilog/BOOT_CLOCK.v
+++ b/sim_models/verilog/BOOT_CLOCK.v
@@ -20,8 +20,7 @@ localparam HALF_PERIOD = PERIOD/2.0;
  initial begin
 
     if ((PERIOD < 16.0) || (PERIOD > 30.0)) begin
-       $display("BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
-    #1 $stop;
+       $fatal(1,"BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
     end
 
   end

--- a/sim_models/verilog/DSP19X2.v
+++ b/sim_models/verilog/DSP19X2.v
@@ -381,15 +381,13 @@ module DSP19X2 #(
 	always @(ACC_FIR)
 		if (ACC_FIR > 21)
 		begin
-			$display("WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
 		end
 	// If SHIFT_RIGHT is greater than 31, result is invalid
 	always @(SHIFT_RIGHT)
 		if (SHIFT_RIGHT > 31)
 		begin
-			$display("WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
 		end
 	
 	always@(*) 
@@ -397,7 +395,7 @@ module DSP19X2 #(
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -409,24 +407,21 @@ module DSP19X2 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/sim_models/verilog/DSP38.v
+++ b/sim_models/verilog/DSP38.v
@@ -297,14 +297,14 @@ module DSP38 #(
 	// If ACC_FIR is greater than 43, result is invalid
 	always @(ACC_FIR)
 		if (ACC_FIR > 43)
-			$display("WARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
+			$fatal(1,"\nWARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
 
 	always@(*) 
 	begin
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -316,24 +316,21 @@ module DSP38 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/sim_models/verilog/FIFO18KX2.v
+++ b/sim_models/verilog/FIFO18KX2.v
@@ -337,48 +337,42 @@ tdp_ram18kx2_inst
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
       end
     endcase
     case(DATA_READ_WIDTH1)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
       end
     endcase
     case(FIFO_TYPE1)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
       end
     endcase
     case(DATA_WRITE_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
       end
     endcase
     case(DATA_READ_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
       end
     endcase
     case(FIFO_TYPE2)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
       end
     endcase
 

--- a/sim_models/verilog/FIFO36K.v
+++ b/sim_models/verilog/FIFO36K.v
@@ -202,8 +202,7 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
       end
     endcase
     case(DATA_READ_WIDTH)
@@ -211,16 +210,14 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
       end
     endcase
     case(FIFO_TYPE)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
       end
     endcase
 

--- a/sim_models/verilog/I_BUF.v
+++ b/sim_models/verilog/I_BUF.v
@@ -31,8 +31,7 @@ module I_BUF #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 

--- a/sim_models/verilog/I_BUF_DS.v
+++ b/sim_models/verilog/I_BUF_DS.v
@@ -44,8 +44,7 @@ module I_BUF_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
     case(IOSTANDARD)
@@ -66,16 +65,14 @@ module I_BUF_DS #(
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
     case(DIFFERENTIAL_TERMINATION)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 

--- a/sim_models/verilog/I_DELAY.v
+++ b/sim_models/verilog/I_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;			// Adjusted Delay for TT corne
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/sim_models/verilog/I_FAB.v
+++ b/sim_models/verilog/I_FAB.v
@@ -2,7 +2,7 @@
 `celldefine
 //
 // I_FAB simulation model
-// Marker Buffer for periphery to fabric transition 
+// Marker Buffer for periphery to fabric transition
 //
 // Copyright (c) 2024 Rapid Silicon, Inc.  All rights reserved.
 //
@@ -12,7 +12,8 @@ module I_FAB (
   output O // Output
 );
 
-   assign O = I ;
+assign O = I ;
+
 
 endmodule
 `endcelldefine

--- a/sim_models/verilog/I_SERDES.v
+++ b/sim_models/verilog/I_SERDES.v
@@ -758,22 +758,19 @@ assign DATA_VALID=!des_fifo_empty;
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
     case(DPA_MODE)
       "NONE" ,
       "DPA" ,
       "CDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
       end
     endcase
 

--- a/sim_models/verilog/O_BUFT.v
+++ b/sim_models/verilog/O_BUFT.v
@@ -31,8 +31,7 @@ module O_BUFT #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 

--- a/sim_models/verilog/O_BUFT_DS.v
+++ b/sim_models/verilog/O_BUFT_DS.v
@@ -35,8 +35,7 @@ module O_BUFT_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 

--- a/sim_models/verilog/O_DELAY.v
+++ b/sim_models/verilog/O_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;				// Adjusted Delay for TT corn
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/sim_models/verilog/O_FAB.v
+++ b/sim_models/verilog/O_FAB.v
@@ -2,7 +2,7 @@
 `celldefine
 //
 // O_FAB simulation model
-// Marker Buffer for fabric to periphery transition 
+// Marker Buffer for fabric to periphery transition
 //
 // Copyright (c) 2024 Rapid Silicon, Inc.  All rights reserved.
 //
@@ -12,7 +12,7 @@ module O_FAB (
   output O // Output
 );
 
-   assign O = I ;
+assign O = I ;
 
 endmodule
 `endcelldefine

--- a/sim_models/verilog/O_SERDES.v
+++ b/sim_models/verilog/O_SERDES.v
@@ -244,14 +244,12 @@ module O_SERDES #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
 
   end

--- a/sim_models/verilog/O_SERDES_CLK.v
+++ b/sim_models/verilog/O_SERDES_CLK.v
@@ -53,8 +53,7 @@ module O_SERDES_CLK #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
     case(CLOCK_PHASE)
@@ -63,8 +62,7 @@ module O_SERDES_CLK #(
       180 ,
       270: begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
       end
     endcase
 

--- a/sim_models/verilog/SOC_FPGA_TEMPERATURE.v
+++ b/sim_models/verilog/SOC_FPGA_TEMPERATURE.v
@@ -71,8 +71,7 @@ module SOC_FPGA_TEMPERATURE #(
  initial begin
 
     if ((INITIAL_TEMPERATURE < 0) || (INITIAL_TEMPERATURE > 125)) begin
-       $display("SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
-    #1 $stop;
+       $fatal(1,"SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
     end
 
   end

--- a/sim_models/verilog/TDP_RAM18KX2.v
+++ b/sim_models/verilog/TDP_RAM18KX2.v
@@ -168,13 +168,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_A1 = 2'bx;
-          `else
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_A1 <= 2'bx;
+            // verilator lint_on BLKANDNBLK
           `endif
-        end
 
       always @(posedge CLK_B1)
         if (WEN_B1) begin
@@ -212,13 +211,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_B1 = 2'bx;
-          `else    
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_B1 <= 2'bx;
+            // verilator lint_on BLKANDNBLK
           `endif
-        end         
     end
   endgenerate
 
@@ -282,13 +280,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_a_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_A1 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_A1 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
   always @(posedge CLK_B1)
     if (WEN_B1) begin
@@ -336,13 +333,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_b_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_B1 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_B1 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
   // Collision checking
     always @(posedge collision_a_write_flag) begin
@@ -483,13 +479,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_A2 = 2'bx;
-          `else
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_A2 <= 2'bx;
+            // verilator lint_on BLKANDNBLK
           `endif
-        end
 
       always @(posedge CLK_B2)
         if (WEN_B2) begin
@@ -527,13 +522,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_B2 = 2'bx;
-          `else
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_B2 <= 2'bx;
-          `endif    
-        end      
+            // verilator lint_on BLKANDNBLK
+          `endif
     end
   endgenerate
 
@@ -597,13 +591,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_a2_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_A2 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_A2 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
   always @(posedge CLK_B2)
     if (WEN_B2) begin
@@ -651,13 +644,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_b2_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_B2 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_B2 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
     // Collision checking
     always @(posedge collision_a2_write_flag) begin
@@ -852,8 +844,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
       end
     endcase
     case(WRITE_WIDTH_B1)
@@ -863,8 +854,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
       end
     endcase
     case(READ_WIDTH_A1)
@@ -874,8 +864,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
       end
     endcase
     case(READ_WIDTH_B1)
@@ -885,8 +874,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
       end
     endcase
     case(WRITE_WIDTH_A2)
@@ -896,8 +884,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
       end
     endcase
     case(WRITE_WIDTH_B2)
@@ -907,8 +894,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
       end
     endcase
     case(READ_WIDTH_A2)
@@ -918,8 +904,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
       end
     endcase
     case(READ_WIDTH_B2)
@@ -929,8 +914,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
       end
     endcase
 

--- a/sim_models/verilog/TDP_RAM36K.v
+++ b/sim_models/verilog/TDP_RAM36K.v
@@ -141,9 +141,12 @@ module TDP_RAM36K #(
           end
         end
         else
-          // verilator lint_off BLKANDNBLK
-          RPARITY_A <= 4'bx;
-          // verilator lint_on BLKANDNBLK
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
+            RPARITY_A <= 4'bx;
+            // verilator lint_on BLKANDNBLK
+          `endif
+
 
       always @(posedge CLK_B)
         if (WEN_B) begin
@@ -183,9 +186,11 @@ module TDP_RAM36K #(
           end
         end
         else
-          // verilator lint_off BLKANDNBLK
-          RPARITY_B <= 4'bx;
-          // verilator lint_on BLKANDNBLK
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
+            RPARITY_B <= 4'bx;
+            // verilator lint_on BLKANDNBLK
+          `endif
     end
   endgenerate
 
@@ -249,9 +254,11 @@ module TDP_RAM36K #(
       collision_a_read_flag = 0;
     end
     else
-      // verilator lint_off BLKANDNBLK
-      RDATA_A <= 32'bx;
-      // verilator lint_on BLKANDNBLK
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
+        RDATA_A <= 32'bx;
+        // verilator lint_on BLKANDNBLK
+      `endif
 
   always @(posedge CLK_B)
     if (WEN_B) begin
@@ -298,9 +305,11 @@ module TDP_RAM36K #(
       collision_b_read_flag = 0;
     end
     else
-      // verilator lint_off BLKANDNBLK
-      RDATA_B <= 32'bx;
-      // verilator lint_on BLKANDNBLK
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
+        RDATA_B <= 32'bx;
+        // verilator lint_on BLKANDNBLK
+      `endif
 
 
 /*
@@ -479,8 +488,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
       end
     endcase
     case(READ_WIDTH_A)
@@ -491,8 +499,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
       end
     endcase
     case(WRITE_WIDTH_B)
@@ -503,8 +510,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
       end
     endcase
     case(READ_WIDTH_B)
@@ -515,8 +521,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
       end
     endcase
 

--- a/sim_models_internal/verilog/BOOT_CLOCK.v
+++ b/sim_models_internal/verilog/BOOT_CLOCK.v
@@ -20,8 +20,7 @@ localparam HALF_PERIOD = PERIOD/2.0;
  initial begin
 
     if ((PERIOD < 16.0) || (PERIOD > 30.0)) begin
-       $display("BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
-    #1 $stop;
+       $fatal(1,"BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
     end
 
   end

--- a/sim_models_internal/verilog/DSP19X2.v
+++ b/sim_models_internal/verilog/DSP19X2.v
@@ -381,15 +381,13 @@ module DSP19X2 #(
 	always @(ACC_FIR)
 		if (ACC_FIR > 21)
 		begin
-			$display("WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
 		end
 	// If SHIFT_RIGHT is greater than 31, result is invalid
 	always @(SHIFT_RIGHT)
 		if (SHIFT_RIGHT > 31)
 		begin
-			$display("WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
 		end
 	
 	always@(*) 
@@ -397,7 +395,7 @@ module DSP19X2 #(
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -409,24 +407,21 @@ module DSP19X2 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/sim_models_internal/verilog/DSP38.v
+++ b/sim_models_internal/verilog/DSP38.v
@@ -297,14 +297,14 @@ module DSP38 #(
 	// If ACC_FIR is greater than 43, result is invalid
 	always @(ACC_FIR)
 		if (ACC_FIR > 43)
-			$display("WARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
+			$fatal(1,"\nWARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
 
 	always@(*) 
 	begin
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -316,24 +316,21 @@ module DSP38 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/sim_models_internal/verilog/FIFO18KX2.v
+++ b/sim_models_internal/verilog/FIFO18KX2.v
@@ -337,48 +337,42 @@ tdp_ram18kx2_inst
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
       end
     endcase
     case(DATA_READ_WIDTH1)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
       end
     endcase
     case(FIFO_TYPE1)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
       end
     endcase
     case(DATA_WRITE_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
       end
     endcase
     case(DATA_READ_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
       end
     endcase
     case(FIFO_TYPE2)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
       end
     endcase
 

--- a/sim_models_internal/verilog/FIFO36K.v
+++ b/sim_models_internal/verilog/FIFO36K.v
@@ -202,8 +202,7 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
       end
     endcase
     case(DATA_READ_WIDTH)
@@ -211,16 +210,14 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
       end
     endcase
     case(FIFO_TYPE)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
       end
     endcase
 

--- a/sim_models_internal/verilog/I_BUF.v
+++ b/sim_models_internal/verilog/I_BUF.v
@@ -34,8 +34,7 @@ module I_BUF #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 

--- a/sim_models_internal/verilog/I_BUF.v
+++ b/sim_models_internal/verilog/I_BUF.v
@@ -68,8 +68,7 @@ module I_BUF #(
       "SSTL_I_33" ,
       "SSTL_II_33": begin end
       default: begin
-        $display("\nError: I_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/sim_models_internal/verilog/I_BUF_DS.v
+++ b/sim_models_internal/verilog/I_BUF_DS.v
@@ -44,8 +44,7 @@ module I_BUF_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
     case(IOSTANDARD)
@@ -66,16 +65,14 @@ module I_BUF_DS #(
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
     case(DIFFERENTIAL_TERMINATION)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 

--- a/sim_models_internal/verilog/I_DELAY.v
+++ b/sim_models_internal/verilog/I_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;			// Adjusted Delay for TT corne
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/sim_models_internal/verilog/I_FAB.v
+++ b/sim_models_internal/verilog/I_FAB.v
@@ -2,7 +2,7 @@
 `celldefine
 //
 // I_FAB simulation model
-// Marker Buffer for periphery to fabric transition 
+// Marker Buffer for periphery to fabric transition
 //
 // Copyright (c) 2024 Rapid Silicon, Inc.  All rights reserved.
 //
@@ -12,7 +12,8 @@ module I_FAB (
   output O // Output
 );
 
-   assign O = I ;
+assign O = I ;
+
 
 endmodule
 `endcelldefine

--- a/sim_models_internal/verilog/I_SERDES.v
+++ b/sim_models_internal/verilog/I_SERDES.v
@@ -758,22 +758,19 @@ assign DATA_VALID=!des_fifo_empty;
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
     case(DPA_MODE)
       "NONE" ,
       "DPA" ,
       "CDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
       end
     endcase
 

--- a/sim_models_internal/verilog/O_BUF.v
+++ b/sim_models_internal/verilog/O_BUF.v
@@ -53,8 +53,7 @@ module O_BUF
       "SSTL_I_33" ,
       "SSTL_II_33": begin end
       default: begin
-        $display("\nError: O_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
       end
     endcase
 
@@ -66,8 +65,7 @@ module O_BUF
       12 ,
       16: begin end
       default: begin
-        $display("\nError: O_BUF instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
       end
     endcase
 
@@ -75,8 +73,7 @@ module O_BUF
       "SLOW" ,
       "FAST": begin end
       default: begin
-        $display("\nError: O_BUF instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/sim_models_internal/verilog/O_BUFT.v
+++ b/sim_models_internal/verilog/O_BUFT.v
@@ -36,8 +36,7 @@ module O_BUFT #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 
@@ -71,8 +70,7 @@ module O_BUFT #(
       "SSTL_I_33" ,
       "SSTL_II_33": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
       end
     endcase
 
@@ -84,8 +82,7 @@ module O_BUFT #(
       12 ,
       16: begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
       end
     endcase
 
@@ -93,8 +90,7 @@ module O_BUFT #(
       "SLOW" ,
       "FAST": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/sim_models_internal/verilog/O_BUFT_DS.v
+++ b/sim_models_internal/verilog/O_BUFT_DS.v
@@ -39,8 +39,7 @@ module O_BUFT_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 
@@ -64,8 +63,7 @@ module O_BUFT_DS #(
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
 
@@ -73,8 +71,7 @@ module O_BUFT_DS #(
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/sim_models_internal/verilog/O_BUF_DS.v
+++ b/sim_models_internal/verilog/O_BUF_DS.v
@@ -45,8 +45,7 @@ module O_BUF_DS
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: O_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
 
@@ -54,8 +53,7 @@ module O_BUF_DS
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: O_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/sim_models_internal/verilog/O_DELAY.v
+++ b/sim_models_internal/verilog/O_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;				// Adjusted Delay for TT corn
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/sim_models_internal/verilog/O_FAB.v
+++ b/sim_models_internal/verilog/O_FAB.v
@@ -2,7 +2,7 @@
 `celldefine
 //
 // O_FAB simulation model
-// Marker Buffer for fabric to periphery transition 
+// Marker Buffer for fabric to periphery transition
 //
 // Copyright (c) 2024 Rapid Silicon, Inc.  All rights reserved.
 //
@@ -12,7 +12,7 @@ module O_FAB (
   output O // Output
 );
 
-   assign O = I ;
+assign O = I ;
 
 endmodule
 `endcelldefine

--- a/sim_models_internal/verilog/O_SERDES.v
+++ b/sim_models_internal/verilog/O_SERDES.v
@@ -244,14 +244,12 @@ module O_SERDES #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
 
   end

--- a/sim_models_internal/verilog/O_SERDES_CLK.v
+++ b/sim_models_internal/verilog/O_SERDES_CLK.v
@@ -53,8 +53,7 @@ module O_SERDES_CLK #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
     case(CLOCK_PHASE)
@@ -63,8 +62,7 @@ module O_SERDES_CLK #(
       180 ,
       270: begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
       end
     endcase
 

--- a/sim_models_internal/verilog/PLL.v
+++ b/sim_models_internal/verilog/PLL.v
@@ -160,12 +160,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN) begin
 		if(pllstart_ff2)begin
 			if (ref_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
 			end
 			else if (ref_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -182,12 +180,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge FAST_CLK) begin
 		if(vcostart_ff) begin
 			if (vco_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
 			end
 			else if (vco_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -198,19 +194,16 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN, posedge PLL_EN) begin
 		if(PLL_EN)begin
 			if(PLL_POST_DIV0==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
-            $stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 			else if(PLL_POST_DIV1==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 
 			else if(PLL_POST_DIV1>PLL_POST_DIV0) begin
-				$display("Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
 			end
 		end
 	end
@@ -219,33 +212,28 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
     case(DEV_FAMILY)
       "VIRGO": begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter DEV_FAMILY set to %s.  Valid values are VIRGO\n", DEV_FAMILY);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter DEV_FAMILY set to %s.  Valid values are VIRGO\n", DEV_FAMILY);
       end
     endcase
     case(DIVIDE_CLK_IN_BY_2)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter DIVIDE_CLK_IN_BY_2 set to %s.  Valid values are TRUE, FALSE\n", DIVIDE_CLK_IN_BY_2);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter DIVIDE_CLK_IN_BY_2 set to %s.  Valid values are TRUE, FALSE\n", DIVIDE_CLK_IN_BY_2);
       end
     endcase
 
     if ((PLL_MULT < 16) || (PLL_MULT > 640)) begin
-       $display("PLL instance %m PLL_MULT set to incorrect value, %d.  Values must be between 16 and 640.", PLL_MULT);
-    #1 $stop;
+       $fatal(1,"PLL instance %m PLL_MULT set to incorrect value, %d.  Values must be between 16 and 640.", PLL_MULT);
     end
 
     if ((PLL_DIV < 1) || (PLL_DIV > 63)) begin
-       $display("PLL instance %m PLL_DIV set to incorrect value, %d.  Values must be between 1 and 63.", PLL_DIV);
-    #1 $stop;
+       $fatal(1,"PLL instance %m PLL_DIV set to incorrect value, %d.  Values must be between 1 and 63.", PLL_DIV);
     end
     case(PLL_MULT_FRAC)
       0: begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter PLL_MULT_FRAC set to %d.  Valid values are 0\n", PLL_MULT_FRAC);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter PLL_MULT_FRAC set to %d.  Valid values are 0\n", PLL_MULT_FRAC);
       end
     endcase
     case(PLL_POST_DIV)
@@ -278,8 +266,7 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
       103 ,
       119: begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter PLL_POST_DIV set to %d.  Valid values are 17, 18, 19, 20, 21, 22, 23, 34, 35, 36, 37, 38, 39, 51, 52, 53, 54, 55, 68, 69, 70, 71, 85, 86, 87, 102, 103, 119\n", PLL_POST_DIV);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter PLL_POST_DIV set to %d.  Valid values are 17, 18, 19, 20, 21, 22, 23, 34, 35, 36, 37, 38, 39, 51, 52, 53, 54, 55, 68, 69, 70, 71, 85, 86, 87, 102, 103, 119\n", PLL_POST_DIV);
       end
     endcase
 

--- a/sim_models_internal/verilog/SOC_FPGA_TEMPERATURE.v
+++ b/sim_models_internal/verilog/SOC_FPGA_TEMPERATURE.v
@@ -71,8 +71,7 @@ module SOC_FPGA_TEMPERATURE #(
  initial begin
 
     if ((INITIAL_TEMPERATURE < 0) || (INITIAL_TEMPERATURE > 125)) begin
-       $display("SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
-    #1 $stop;
+       $fatal(1,"SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
     end
 
   end

--- a/sim_models_internal/verilog/TDP_RAM18KX2.v
+++ b/sim_models_internal/verilog/TDP_RAM18KX2.v
@@ -168,13 +168,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_A1 = 2'bx;
-          `else
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_A1 <= 2'bx;
+            // verilator lint_on BLKANDNBLK
           `endif
-        end
 
       always @(posedge CLK_B1)
         if (WEN_B1) begin
@@ -212,13 +211,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_B1 = 2'bx;
-          `else    
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_B1 <= 2'bx;
+            // verilator lint_on BLKANDNBLK
           `endif
-        end         
     end
   endgenerate
 
@@ -282,13 +280,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_a_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_A1 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_A1 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
   always @(posedge CLK_B1)
     if (WEN_B1) begin
@@ -336,13 +333,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_b_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_B1 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_B1 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
   // Collision checking
     always @(posedge collision_a_write_flag) begin
@@ -483,13 +479,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_A2 = 2'bx;
-          `else
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_A2 <= 2'bx;
+            // verilator lint_on BLKANDNBLK
           `endif
-        end
 
       always @(posedge CLK_B2)
         if (WEN_B2) begin
@@ -527,13 +522,12 @@ module TDP_RAM18KX2 #(
             `endif
           end
         end
-        else begin
-          `ifdef SIM_VERILATOR
-            RPARITY_B2 = 2'bx;
-          `else
+        else
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
             RPARITY_B2 <= 2'bx;
-          `endif    
-        end      
+            // verilator lint_on BLKANDNBLK
+          `endif
     end
   endgenerate
 
@@ -597,13 +591,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_a2_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_A2 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_A2 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
   always @(posedge CLK_B2)
     if (WEN_B2) begin
@@ -651,13 +644,12 @@ module TDP_RAM18KX2 #(
       #collision_window;
       collision_b2_read_flag = 0;
     end
-    else begin
-      `ifdef SIM_VERILATOR
-        RDATA_B2 = 16'bx;
-      `else
+    else
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
         RDATA_B2 <= 16'bx;
+        // verilator lint_on BLKANDNBLK
       `endif
-    end
 
     // Collision checking
     always @(posedge collision_a2_write_flag) begin
@@ -852,8 +844,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
       end
     endcase
     case(WRITE_WIDTH_B1)
@@ -863,8 +854,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
       end
     endcase
     case(READ_WIDTH_A1)
@@ -874,8 +864,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
       end
     endcase
     case(READ_WIDTH_B1)
@@ -885,8 +874,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
       end
     endcase
     case(WRITE_WIDTH_A2)
@@ -896,8 +884,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
       end
     endcase
     case(WRITE_WIDTH_B2)
@@ -907,8 +894,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
       end
     endcase
     case(READ_WIDTH_A2)
@@ -918,8 +904,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
       end
     endcase
     case(READ_WIDTH_B2)
@@ -929,8 +914,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
       end
     endcase
 

--- a/sim_models_internal/verilog/TDP_RAM36K.v
+++ b/sim_models_internal/verilog/TDP_RAM36K.v
@@ -141,9 +141,12 @@ module TDP_RAM36K #(
           end
         end
         else
-          // verilator lint_off BLKANDNBLK
-          RPARITY_A <= 4'bx;
-          // verilator lint_on BLKANDNBLK
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
+            RPARITY_A <= 4'bx;
+            // verilator lint_on BLKANDNBLK
+          `endif
+
 
       always @(posedge CLK_B)
         if (WEN_B) begin
@@ -183,9 +186,11 @@ module TDP_RAM36K #(
           end
         end
         else
-          // verilator lint_off BLKANDNBLK
-          RPARITY_B <= 4'bx;
-          // verilator lint_on BLKANDNBLK
+          `ifndef FIFO
+            // verilator lint_off BLKANDNBLK
+            RPARITY_B <= 4'bx;
+            // verilator lint_on BLKANDNBLK
+          `endif
     end
   endgenerate
 
@@ -249,9 +254,11 @@ module TDP_RAM36K #(
       collision_a_read_flag = 0;
     end
     else
-      // verilator lint_off BLKANDNBLK
-      RDATA_A <= 32'bx;
-      // verilator lint_on BLKANDNBLK
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
+        RDATA_A <= 32'bx;
+        // verilator lint_on BLKANDNBLK
+      `endif
 
   always @(posedge CLK_B)
     if (WEN_B) begin
@@ -298,9 +305,11 @@ module TDP_RAM36K #(
       collision_b_read_flag = 0;
     end
     else
-      // verilator lint_off BLKANDNBLK
-      RDATA_B <= 32'bx;
-      // verilator lint_on BLKANDNBLK
+      `ifndef FIFO
+        // verilator lint_off BLKANDNBLK
+        RDATA_B <= 32'bx;
+        // verilator lint_on BLKANDNBLK
+      `endif
 
 
 /*
@@ -479,8 +488,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
       end
     endcase
     case(READ_WIDTH_A)
@@ -491,8 +499,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
       end
     endcase
     case(WRITE_WIDTH_B)
@@ -503,8 +510,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
       end
     endcase
     case(READ_WIDTH_B)
@@ -515,8 +521,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
       end
     endcase
 

--- a/sim_models_internal/verilog/tb/I_FAB_tb.v
+++ b/sim_models_internal/verilog/tb/I_FAB_tb.v
@@ -1,0 +1,43 @@
+
+module I_FAB_tb;
+
+  // Parameters
+
+  //Ports
+  reg  I;
+  wire  O;
+  int error;
+
+  I_FAB  I_FAB_inst (
+    .I(I),
+    .O(O)
+  );
+
+  initial 
+  begin
+    I = 0;
+    error = 0;
+    #3;
+    I = 1;
+    for(int i=0;i<=63;i++)
+	begin
+    #3;
+		I = $urandom;
+    #1;
+		if(O!==I)
+      error++;
+	end
+
+    if(error===0)
+        $display("I_FAB Test Passed");
+    else
+        $error("I_FAB Test Failed");
+            
+  end
+  initial 
+  begin
+      $dumpfile("I_FAB.vcd");
+      $dumpvars;
+  end
+
+endmodule

--- a/sim_models_internal/verilog/tb/O_FAB_tb.v
+++ b/sim_models_internal/verilog/tb/O_FAB_tb.v
@@ -1,0 +1,43 @@
+
+module O_FAB_tb;
+
+  // Parameters
+
+  //Ports
+  reg  I;
+  wire  O;
+  int error;
+
+  O_FAB  O_FAB_inst (
+    .I(I),
+    .O(O)
+  );
+
+  initial 
+  begin
+    I = 0;
+    error = 0;
+    #3;
+    I = 1;
+    for(int i=0;i<=63;i++)
+	begin
+        #3;
+		I = $urandom;
+        #1;
+		if(O!==I)
+            error++;
+	end
+
+    if(error===0)
+        $display("O_FAB TEST PASSED");
+    else
+        $error("O_FAB TEST FAILED");
+            
+  end
+  initial 
+  begin
+      $dumpfile("waves.vcd");
+      $dumpvars;
+  end
+
+endmodule

--- a/sim_models_internal/verilog/tb/SOC_FPGA_INTF_AHB_M_tb.v
+++ b/sim_models_internal/verilog/tb/SOC_FPGA_INTF_AHB_M_tb.v
@@ -1,0 +1,141 @@
+module SOC_FPGA_INTF_AHB_M_tb;
+
+parameter repeat_test=10;
+
+    logic HRESETN_I; 
+    logic [31:0] HADDR; 
+    logic [2:0] HBURST; 
+    logic [3:0] HPROT; 
+    logic [2:0] HSIZE; 
+    logic [1:0] HTRANS; 
+    logic [31:0] HWDATA; 
+    logic HWRITE; 
+    logic [31:0] HRDATA; 
+    logic HREADY; 
+    logic HRESP; 
+    logic HCLK; 
+    
+    logic trans_fail;
+    logic [31:0] r_data;
+    int error;
+    enum logic [1:0] {IDLE, BUSY, NONSEQ, SEQ} htrans;
+              
+    SOC_FPGA_INTF_AHB_M ahb_s(
+        .HRESETN_I(HRESETN_I), 
+        .HADDR(HADDR), 
+        .HBURST(HBURST), 
+        .HPROT(HPROT), 
+        .HSIZE(HSIZE), 
+        .HTRANS(HTRANS), 
+        .HWDATA(HWDATA), 
+        .HWRITE(HWRITE), 
+        .HRDATA(HRDATA), 
+        .HREADY(HREADY), 
+        .HRESP(HRESP), 
+        .HCLK(HCLK) 
+    );
+
+    initial begin
+        HRESETN_I <= 1'b0;
+        HADDR <= '0; 
+        HBURST <= '0; 
+        HPROT <= '0; 
+        HSIZE <= '0; 
+        HTRANS <= '0; 
+        HWDATA <= '0; 
+        HWRITE <= '0; 
+        HCLK <= '0;
+        #10;
+        repeat(2) @(posedge HCLK);
+        HRESETN_I <= 1'b1;
+        $info("Reset observed");
+        for(int i=1; i<repeat_test; i++) begin
+            write(i, 32'h5555_5555 + i);  
+        end
+
+        for(int i=1; i<repeat_test; i++) begin
+            read(i, r_data);  
+            compare(32'h5555_5555 + i, r_data);
+        end
+        
+        if(error > 0)
+        $info("TEST FAILED!");
+        else $info("TEST PASSED!");
+
+        $finish;
+       
+    end
+
+
+    task write(
+        input [31:0] addr,
+        input [31:0] data
+    );
+        @(posedge HCLK);
+        while(!HREADY)  @(posedge HCLK);
+        HBURST <= 3'b000;
+        HPROT <= '0;
+        HSIZE <= 3'b010;
+        HTRANS <= 2'b10;
+
+        HWRITE <= 1'b1;
+        HADDR <= addr;
+        // @(posedge HCLK iff HREADY === 1);
+        do begin
+            @(posedge HCLK);
+            if(HRESP) begin
+                $fatal(1, "Error Response! Transfer Failed");
+                return;
+            end
+        end
+        while(!HREADY);
+        HWDATA <= data;
+    endtask
+
+    task read(
+        input [31:0] addr,
+        output [31:0] data
+    );
+        @(posedge HCLK);
+        while(!HREADY)  @(posedge HCLK);
+        HBURST <= 3'b000;
+        HPROT <= '0;
+        HSIZE <= 3'b010;
+        HTRANS <= 2'b10;
+
+        HWRITE <= 1'b0;
+        HADDR <= addr;
+        // @(posedge HCLK iff HREADY === 1);
+        do begin
+            @(posedge HCLK);
+            if(HRESP) begin
+                $fatal(1, "Error Response! Transfer Failed");
+                return;
+            end
+        end
+        while(!HREADY);
+        data = HRDATA;
+        $info("read data: 0x%0x, HRDATA:0x%0x", data, HRDATA);
+    endtask
+
+    function void compare(logic [31:0] w_data, logic [31:0] r_data);
+        if(w_data!=r_data) begin
+            $info("Missmatch: input=0x%0x, output=0x%0x", w_data, r_data);
+            error++;
+        end
+        else 
+            $info("Match: input=0x%0x, output=0x%0x", w_data, r_data);
+    endfunction
+
+    always #5 HCLK <= ~HCLK;
+
+
+        initial begin
+            integer idx;
+            $dumpfile("dump.vcd");
+            $dumpvars();
+            for(idx=0; idx<32; idx=idx+1)
+                $dumpvars(0, SOC_FPGA_INTF_AHB_M_tb.ahb_s.mem[idx]);
+          end
+
+endmodule

--- a/sim_models_internal/verilog/tb/SOC_FPGA_INTF_AHB_S_tb.v
+++ b/sim_models_internal/verilog/tb/SOC_FPGA_INTF_AHB_S_tb.v
@@ -1,0 +1,121 @@
+module SOC_FPGA_INTF_AHB_S_tb(
+    // input HRESETN_I, // None
+    // input [31:0] HADDR, // None
+    // input [2:0] HBURST, // None
+    // input [3:0] HPROT, // None
+    // input [2:0] HSIZE, // None
+    // input [1:0] HTRANS, // None
+    // input [31:0] HWDATA, // None
+    // input HWRITE, // None
+    // output logic [31:0] HRDATA, // None
+    // output logic HREADY, // None
+    // output logic HRESP, // None
+    // input HCLK // None
+);
+
+parameter repeat_test=10;
+
+
+
+
+    logic HRESETN_I; 
+    logic [31:0] HADDR; 
+    logic [2:0] HBURST; 
+    logic HMASTLOCK; 
+    logic [3:0] HPROT; 
+    logic [2:0] HSIZE; 
+    logic [1:0] HTRANS; 
+    logic [3:0] HWBE; 
+    logic [31:0] HWDATA; 
+    logic HWRITE; 
+    logic HSEL;
+    logic [31:0] HRDATA; 
+    logic HREADY; 
+    logic HRESP; 
+
+    logic HCLK; 
+    
+    logic [31:0] addr_i;
+    logic [31:0] mem[1024];
+    bit [2:0] wait_states;
+    int error;
+    enum logic [1:0] {IDLE, BUSY, NONSEQ, SEQ} htrans;
+              
+    SOC_FPGA_INTF_AHB_S ahb_m(
+        .HRESETN_I(HRESETN_I), 
+        .HADDR(HADDR), 
+        .HBURST(HBURST), 
+        .HMASTLOCK(HMASTLOCK), 
+        .HPROT(HPROT), 
+        .HSIZE(HSIZE), 
+        .HTRANS(HTRANS), 
+        .HWDATA(HWDATA), 
+        .HWWRITE(HWRITE), 
+        .HRDATA(HRDATA), 
+        .HREADY(HREADY), 
+        .HRESP(HRESP), 
+        .HSEL(HSEL), 
+        .HWBE(HWBE), 
+        .HCLK(HCLK) 
+    );
+
+    initial begin
+        int idx;
+        // HRESETN_I <= 1'b0;
+        // HREADY <= 1'b0;
+        HCLK <= 0;
+        HRESP <= 1'b0;
+        // repeat(2) @(posedge HCLK);
+        // HRESETN_I <= 1'b1;
+        HREADY <= 1'b1;
+        // HSEL <= 1'b1;
+
+        // for(int i=0; i<20; i++) mem[i]=i+32'haaaaaaaa;
+        // forever begin
+        //     @(posedge HCLK) HRDATA <= mem[idx];
+        //     if(idx>11) idx=0;
+        //     else idx++;
+        // end 
+        
+    end
+
+
+    initial begin
+        // #1;
+        // @(posedge HCLK);
+        // @(posedge HRESETN_I === 1'b1);
+        $info("reset asserted in slave");
+        forever begin
+
+            wait_states = $urandom();
+            $display("#################### wait states:%0d ###########################", wait_states);
+
+            if(HTRANS==NONSEQ & HSEL === 1'b1)begin
+                addr_i = HADDR;
+                $info("addr:%0d", addr_i);
+                for(int i=0; i< wait_states; i++) begin
+                    HREADY <= 1'b0;
+                    @(posedge HCLK);
+                end
+                @(negedge HCLK);
+                if(HWRITE==0) begin
+                    HRDATA <= mem[addr_i];
+                end
+                HREADY <= 1'b1;
+                @(posedge HCLK);
+                if(HWRITE==1) begin
+                    mem[addr_i] <= HWDATA;
+                    $info("******* write addr:%0d, write_data:0x%0x *************", addr_i, HWDATA);
+                end                    
+                HREADY <= 1'b1;
+            
+            end
+            // @(posedge HCLK);
+            #1;
+
+        end
+    end
+
+    always #5 HCLK <= ~HCLK;
+
+endmodule

--- a/sim_models_internal/verilog/tb/TDP_RAM18KX2_tb.v
+++ b/sim_models_internal/verilog/tb/TDP_RAM18KX2_tb.v
@@ -691,7 +691,7 @@ begin
 end
 endtask
 
-task compare(input reg [RAM1_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM1_ADDR_WIDTH-1:0] addr, input reg parity);
+task compare(input bit [RAM1_DATA_WIDTH-1:0] dout, exp_dout, input bit [RAM1_ADDR_WIDTH-1:0] addr, input bit parity);
 	if (RAM1_PARITY_WIDTH < 1 && parity == 1)
 		exp_dout = 0;
 	if(dout !== exp_dout) begin
@@ -708,7 +708,7 @@ task compare(input reg [RAM1_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM1_ADD
 			$display("Data:: Write/Read MATCHED. Address: %0h, DUT_Out: %0h, Exp_Out: %0h, Time: %0t", addr, dout, exp_dout,$time);
 endtask
 
-task compare_RAM2(input reg [RAM2_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM2_ADDR_WIDTH-1:0] addr, input reg parity);
+task compare_RAM2(input bit [RAM2_DATA_WIDTH-1:0] dout, exp_dout, input bit [RAM2_ADDR_WIDTH-1:0] addr, input bit parity);
 	if (RAM2_PARITY_WIDTH < 1 && parity == 1)
 		exp_dout = 0;
 	if(dout !== exp_dout) begin

--- a/sim_models_internal/verilog/tb/TDP_RAM36K_tb.v
+++ b/sim_models_internal/verilog/tb/TDP_RAM36K_tb.v
@@ -31,10 +31,10 @@ module TDP_RAM36K_tb();
 	/* verilator lint_off WIDTHCONCAT */
   parameter [4095:0] INIT_PARITY = {4096{1'b0}}; // Initial Contents of memory
 	/* verilator lint_on WIDTHCONCAT */
-  parameter WRITE_WIDTH_A = 36; // Write data width on port A (1-36)
-  parameter READ_WIDTH_A = 	36; // Read data width on port A (1-36)
-  parameter WRITE_WIDTH_B = 36; // Write data width on port B (1-36)
-  parameter READ_WIDTH_B = 	36; // Read data width on port B (1-36)
+  parameter WRITE_WIDTH_A = 18; // Write data width on port A (1-36)
+  parameter READ_WIDTH_A = 	18; // Read data width on port A (1-36)
+  parameter WRITE_WIDTH_B = 18; // Write data width on port B (1-36)
+  parameter READ_WIDTH_B = 	18; // Read data width on port B (1-36)
 
 	//Local_RAM
   localparam A_DATA_WRITE_WIDTH = calc_data_width(WRITE_WIDTH_A);
@@ -612,7 +612,7 @@ begin
 end
 endtask
 
-task compare(input reg [RAM_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM_ADDR_WIDTH-1:0] addr, input reg parity);
+task compare(input bit [RAM_DATA_WIDTH-1:0] dout, exp_dout, input bit [RAM_ADDR_WIDTH-1:0] addr, input bit parity);
 	if (RAM_PARITY_WIDTH < 1 && parity == 1)
 		exp_dout = 0;
 	if(dout !== exp_dout) begin

--- a/tb/BOOT_CLOCK/BOOT_CLOCK_tb.v
+++ b/tb/BOOT_CLOCK/BOOT_CLOCK_tb.v
@@ -1,3 +1,4 @@
+`timescale 1ns/1ps
 
 module BOOT_CLOCK_tb;
 

--- a/tb/I_FAB/I_FAB_tb.v
+++ b/tb/I_FAB/I_FAB_tb.v
@@ -1,0 +1,43 @@
+
+module I_FAB_tb;
+
+  // Parameters
+
+  //Ports
+  reg  I;
+  wire  O;
+  int error;
+
+  I_FAB  I_FAB_inst (
+    .I(I),
+    .O(O)
+  );
+
+  initial 
+  begin
+    I = 0;
+    error = 0;
+    #3;
+    I = 1;
+    for(int i=0;i<=63;i++)
+	begin
+    #3;
+		I = $urandom;
+    #1;
+		if(O!==I)
+      error++;
+	end
+
+    if(error===0)
+        $display("I_FAB Test Passed");
+    else
+        $error("I_FAB Test Failed");
+            
+  end
+  initial 
+  begin
+      $dumpfile("I_FAB.vcd");
+      $dumpvars;
+  end
+
+endmodule

--- a/tb/O_BUF/O_BUF_tb.v
+++ b/tb/O_BUF/O_BUF_tb.v
@@ -6,7 +6,7 @@ module O_BUF_tb;
   wire O1, O2;
   reg CLK = 0;
   integer mismatch = 0;
-  localparam IOSTANDARD = "NONE";
+  localparam IOSTANDARD = "DEFAULT";
   localparam DRIVE_STRENGTH = 2;
   localparam SLEW_RATE = "SLOW";
   always #5 CLK = ~CLK;

--- a/tb/O_FAB/O_FAB_tb.v
+++ b/tb/O_FAB/O_FAB_tb.v
@@ -1,0 +1,43 @@
+
+module O_FAB_tb;
+
+  // Parameters
+
+  //Ports
+  reg  I;
+  wire  O;
+  int error;
+
+  O_FAB  O_FAB_inst (
+    .I(I),
+    .O(O)
+  );
+
+  initial 
+  begin
+    I = 0;
+    error = 0;
+    #3;
+    I = 1;
+    for(int i=0;i<=63;i++)
+	begin
+    #3;
+		I = $urandom;
+    #1;
+		if(O!==I)
+      error++;
+	end
+
+    if(error===0)
+        $display("O_FAB Test Passed");
+    else
+        $error("O_FAB Test Failed");
+            
+  end
+  initial 
+  begin
+      $dumpfile("O_FAB.vcd");
+      $dumpvars;
+  end
+
+endmodule

--- a/tb/TDP_RAM18KX2/TDP_RAM18KX2_tb.v
+++ b/tb/TDP_RAM18KX2/TDP_RAM18KX2_tb.v
@@ -1,3 +1,4 @@
+`timescale 1ns/1ps
 // Self-Checking Testbench for TDP_RAM18KX2 simulation model
 // Testbench Not modeled for ASymmetric RAM
 // So, Keep the Write/Read Width Same for Both Ports
@@ -42,20 +43,22 @@ module TDP_RAM18KX2_tb();
 	wire [READ_WIDTH_B2-1:0] RDATA_B2; // Read data port B, RAM 2
 	wire [1:0] RPARITY_B2; // Read parity port B, RAM 2
 
-	parameter [18431:0] INIT1 = {18432{1'b0}}; // Initial Contents of memory, RAM 1
+	/* verilator lint_off WIDTHCONCAT */
+	/* verilator lint_off WIDTH */
+	parameter [16383:0] INIT1 = {16384{1'b0}}; // Initial Contents of memory, RAM 1
 	parameter [2047:0] INIT1_PARITY = {2048{1'b0}}; // Initial Contents of memory
 	parameter WRITE_WIDTH_A1 = 18; // Write data width on port A, RAM 1 (1-18)
 	parameter WRITE_WIDTH_B1 = 18; // Write data width on port B, RAM 1 (1-18)
 	parameter READ_WIDTH_A1 = 18; // Read data width on port A, RAM 1 (1-18)
 	parameter READ_WIDTH_B1 = 18; // Read data width on port B, RAM 1 (1-18)
-	parameter [18431:0] INIT2 = {18432{1'b0}}; // Initial Contents of memory, RAM 2
+	parameter [16383:0] INIT2 = {16384{1'b0}}; // Initial Contents of memory, RAM 2
 	parameter [2047:0] INIT2_PARITY = {2048{1'b0}}; // Initial Contents of memory
 	parameter WRITE_WIDTH_A2 = 9; // Write data width on port A, RAM 2 (1-18)
 	parameter WRITE_WIDTH_B2 = 9; // Write data width on port B, RAM 2 (1-18)
 	parameter READ_WIDTH_A2 = 9; // Read data width on port A, RAM 2 (1-18)
 	parameter READ_WIDTH_B2 = 9; // Read data width on port B, RAM 2 (1-18)
 
-	//Local_RAM1
+//Local_RAM1
   localparam A1_DATA_WRITE_WIDTH = calc_data_width(WRITE_WIDTH_A1);
   localparam A1_WRITE_ADDR_WIDTH = calc_depth(A1_DATA_WRITE_WIDTH);
   localparam A1_DATA_READ_WIDTH = calc_data_width(READ_WIDTH_A1);
@@ -88,7 +91,9 @@ localparam A1_PARITY_WRITE_WIDTH = calc_parity_width(WRITE_WIDTH_A1);
 	reg [RAM1_ADDR_WIDTH-1:0] temp_ram1_addr;
 
 	// Parity Ram
+	/* verilator lint_off LITENDIAN */
 	reg [RAM1_PARITY_WIDTH-1:0] local_parity_ram1 [2**RAM1_ADDR_WIDTH-1:0];
+	/* verilator lint_on LITENDIAN */
 
 	integer f_p, g_p, h_p;
 	integer f, g, h, i, j, k, m;
@@ -98,7 +103,11 @@ localparam A1_PARITY_WRITE_WIDTH = calc_parity_width(WRITE_WIDTH_A1);
 		f_p = 0;
 		for (g_p = 0; g_p < 2**RAM1_ADDR_WIDTH; g_p = g_p + 1)
 			for (h_p = 0; h_p < RAM1_PARITY_WIDTH; h_p = h_p + 1) begin
-				local_parity_ram1[g_p][h_p] <= INIT1_PARITY[f_p];
+				`ifdef SIM_VERILATOR
+					local_parity_ram1[g_p][h_p] = INIT1_PARITY[f_p];
+				`else
+					local_parity_ram1[g_p][h_p] <= INIT1_PARITY[f_p];
+				`endif
 				f_p = f_p + 1;
 			end
 	end
@@ -108,7 +117,11 @@ localparam A1_PARITY_WRITE_WIDTH = calc_parity_width(WRITE_WIDTH_A1);
 			f = 0;
 			for (g = 0; g < 2**RAM1_ADDR_WIDTH; g = g + 1)
 				for (h = 0; h < RAM1_DATA_WIDTH; h = h + 1) begin
-					local_ram1[g][h] <= INIT1[f];
+					`ifdef SIM_VERILATOR
+						local_ram1[g][h] = INIT1[f];
+					`else
+						local_ram1[g][h] <= INIT1[f];
+					`endif
 					f = f + 1;
 				end
 		end
@@ -146,7 +159,9 @@ localparam A1_PARITY_WRITE_WIDTH = calc_parity_width(WRITE_WIDTH_A1);
 	reg [RAM2_ADDR_WIDTH-1:0] temp_ram2_addr;
 
 	// Parity Ram
+	/* verilator lint_off LITENDIAN */
 	reg [RAM2_PARITY_WIDTH-1:0] local_parity_ram2 [2**RAM2_ADDR_WIDTH-1:0];
+	/* verilator lint_on LITENDIAN */
 
 	integer a, b, c, l, n, p, r;
 
@@ -157,7 +172,11 @@ localparam A1_PARITY_WRITE_WIDTH = calc_parity_width(WRITE_WIDTH_A1);
 		f_p2 = 0;
 		for (g_p2 = 0; g_p2 < 2**RAM2_ADDR_WIDTH; g_p2 = g_p2 + 1)
 			for (h_p2 = 0; h_p2 < RAM2_PARITY_WIDTH; h_p2 = h_p2 + 1) begin
-				local_parity_ram2[g_p2][h_p2] <= INIT2_PARITY[f_p2];
+				`ifdef SIM_VERILATOR
+					local_parity_ram2[g_p2][h_p2] = INIT2_PARITY[f_p2];
+				`else
+					local_parity_ram2[g_p2][h_p2] <= INIT2_PARITY[f_p2];
+				`endif
 				f_p2 = f_p2 + 1;
 			end
 	end
@@ -167,7 +186,11 @@ localparam A1_PARITY_WRITE_WIDTH = calc_parity_width(WRITE_WIDTH_A1);
     a = 0;
     for (b = 0; b < 2**RAM2_ADDR_WIDTH; b = b + 1)
       for (c = 0; c < RAM2_DATA_WIDTH; c = c + 1) begin
-        local_ram2[b][c] <= INIT2[a];
+				`ifdef SIM_VERILATOR
+        	local_ram2[b][c] = INIT2[a];
+				`else
+					local_ram2[b][c] <= INIT2[a];
+				`endif
         a = a + 1;
       end
   end
@@ -257,7 +280,7 @@ tdp_ram18kx2_inst
 
 `ifdef VCD
 	initial begin
-		$dumpfile("out/wave.vcd");
+		$dumpfile("wave.vcd");
 		$dumpvars;
 	end
 `endif
@@ -323,13 +346,35 @@ tdp_ram18kx2_inst
 			end
 		end
   join
+  /* verilator lint_on WIDTHCONCAT */
+  /* verilator lint_on WIDTH */
+
+//   // // Collision Check
+//   @(negedge CLK_A1);
+//   ADDR_A1 = 'h0;
+//   WEN_A1 = 1; WDATA_A1 = 'hFFFF;
+//   ADDR_B1 = 'h0;
+//   REN_B1 = 1; WDATA_B1 = 'hFFFF;
+
+  // // RAM2
+
+  // // Collision Check
+  //   @(negedge CLK_A2);
+  //   ADDR_A2 = 'h0;
+  //   WEN_A2 = 1; WDATA_A2 = 'hFFFF;
+  //   ADDR_B2 = 'h0;
+  //   REN_B2 = 1; WDATA_B2 = 'hFFFF;
 
 		test_status(error);
 		#100;
 		$finish();
 
 end
-	
+
+
+  	/* verilator lint_off WIDTH */
+  	/* verilator lint_off SELRANGE */
+  	/* verilator lint_off IGNOREDRETURN */
 	task directed_read_or_write(input reg [RAM_ADDR_WIDTH-1:0] d_addrA, input reg [RAM_ADDR_WIDTH-1:0] d_addrB, input reg [RAM_DATA_WIDTH-1:0] d_dinA, input reg [RAM_DATA_WIDTH-1:0] d_dinB, input reg write, input reg [1:0] portAB);
 	if(write) begin
       if(portAB==2'b00)
@@ -505,7 +550,9 @@ end
     //$display("Addr_A: %0b, Addr_B: %0b, addr_width: %0d, Port: %0h, Time: %0t", ADDR_A1, ADDR_B1, addr_width, portAB,$time);	
   endfunction
 
+	/* verilator lint_off LITENDIAN */
 	function logic [RAM1_DATA_WIDTH-1:0] RAM1_Data_wrt_BE(input reg [RAM1_ADDR_WIDTH-1:0] addr, input reg [RAM1_DATA_WIDTH-1:0] din, input reg [RAM1_PARITY_WIDTH-1:0] parity, input reg [1:0] BE);
+	/* verilator lint_on LITENDIAN */
     logic [RAM1_DATA_WIDTH-1:0] dout;
     if (RAM1_DATA_WIDTH > 9) begin
 			case (BE)
@@ -541,7 +588,9 @@ end
     return dout;
   endfunction
 
+	/* verilator lint_off LITENDIAN */
 	function logic [RAM2_DATA_WIDTH-1:0] RAM2_Data_wrt_BE(input reg [RAM2_ADDR_WIDTH-1:0] addr, input reg [RAM2_DATA_WIDTH-1:0] din, input reg [RAM2_PARITY_WIDTH-1:0] parity, input reg [1:0] BE);
+	/* verilator lint_on LITENDIAN */
     reg [RAM2_DATA_WIDTH-1:0] dout;
     if (RAM2_DATA_WIDTH > 9) begin
 			case (BE)
@@ -576,6 +625,8 @@ end
 		end
     return dout;
   endfunction
+  /* verilator lint_on WIDTH */
+	/* verilator lint_on SELRANGE */
 
 task test_status(input logic [31:0] error);
 begin
@@ -604,7 +655,7 @@ begin
 			$display("");
 			$display("");	
 			$display("----------------------------------------------");
-      		$display("                 Test Passed                  ");
+      $display("                 Test Passed                  ");
 			$display("----------------------------------------------");
     end
     else   
@@ -640,7 +691,7 @@ begin
 end
 endtask
 
-task compare(input reg [RAM1_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM1_ADDR_WIDTH-1:0] addr, input reg parity);
+task compare(input bit [RAM1_DATA_WIDTH-1:0] dout, exp_dout, input bit [RAM1_ADDR_WIDTH-1:0] addr, input bit parity);
 	if (RAM1_PARITY_WIDTH < 1 && parity == 1)
 		exp_dout = 0;
 	if(dout !== exp_dout) begin
@@ -657,7 +708,7 @@ task compare(input reg [RAM1_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM1_ADD
 			$display("Data:: Write/Read MATCHED. Address: %0h, DUT_Out: %0h, Exp_Out: %0h, Time: %0t", addr, dout, exp_dout,$time);
 endtask
 
-task compare_RAM2(input reg [RAM2_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM2_ADDR_WIDTH-1:0] addr, input reg parity);
+task compare_RAM2(input bit [RAM2_DATA_WIDTH-1:0] dout, exp_dout, input bit [RAM2_ADDR_WIDTH-1:0] addr, input bit parity);
 	if (RAM2_PARITY_WIDTH < 1 && parity == 1)
 		exp_dout = 0;
 	if(dout !== exp_dout) begin

--- a/tb/TDP_RAM36K/TDP_RAM36K_tb.v
+++ b/tb/TDP_RAM36K/TDP_RAM36K_tb.v
@@ -31,10 +31,10 @@ module TDP_RAM36K_tb();
 	/* verilator lint_off WIDTHCONCAT */
   parameter [4095:0] INIT_PARITY = {4096{1'b0}}; // Initial Contents of memory
 	/* verilator lint_on WIDTHCONCAT */
-  parameter WRITE_WIDTH_A = 36; // Write data width on port A (1-36)
-  parameter READ_WIDTH_A = 	36; // Read data width on port A (1-36)
-  parameter WRITE_WIDTH_B = 36; // Write data width on port B (1-36)
-  parameter READ_WIDTH_B = 	36; // Read data width on port B (1-36)
+  parameter WRITE_WIDTH_A = 18; // Write data width on port A (1-36)
+  parameter READ_WIDTH_A = 	18; // Read data width on port A (1-36)
+  parameter WRITE_WIDTH_B = 18; // Write data width on port B (1-36)
+  parameter READ_WIDTH_B = 	18; // Read data width on port B (1-36)
 
 	//Local_RAM
   localparam A_DATA_WRITE_WIDTH = calc_data_width(WRITE_WIDTH_A);
@@ -160,7 +160,7 @@ tdp_ram36k_inst
 
 `ifdef VCD
 	initial begin
-		$dumpfile("TDP_RAM36K.vcd");
+		$dumpfile("wave.vcd");
 		$dumpvars;
 	end
 `endif
@@ -576,7 +576,7 @@ begin
 			$display("");
 			$display("");	
 			$display("----------------------------------------------");
-      	$display("                 Test Passed                  ");
+      $display("                 Test Passed                  ");
 			$display("----------------------------------------------");
     end
     else   
@@ -612,7 +612,7 @@ begin
 end
 endtask
 
-task compare(input reg [RAM_DATA_WIDTH-1:0] dout, exp_dout, input reg [RAM_ADDR_WIDTH-1:0] addr, input reg parity);
+task compare(input bit [RAM_DATA_WIDTH-1:0] dout, exp_dout, input bit [RAM_ADDR_WIDTH-1:0] addr, input bit parity);
 	if (RAM_PARITY_WIDTH < 1 && parity == 1)
 		exp_dout = 0;
 	if(dout !== exp_dout) begin

--- a/tb/TDP_RAM36K/TDP_RAM36K_tb.v
+++ b/tb/TDP_RAM36K/TDP_RAM36K_tb.v
@@ -31,10 +31,10 @@ module TDP_RAM36K_tb();
 	/* verilator lint_off WIDTHCONCAT */
   parameter [4095:0] INIT_PARITY = {4096{1'b0}}; // Initial Contents of memory
 	/* verilator lint_on WIDTHCONCAT */
-  parameter WRITE_WIDTH_A = 18; // Write data width on port A (1-36)
-  parameter READ_WIDTH_A = 	18; // Read data width on port A (1-36)
-  parameter WRITE_WIDTH_B = 18; // Write data width on port B (1-36)
-  parameter READ_WIDTH_B = 	18; // Read data width on port B (1-36)
+  parameter WRITE_WIDTH_A = 36; // Write data width on port A (1-36)
+  parameter READ_WIDTH_A = 	36; // Read data width on port A (1-36)
+  parameter WRITE_WIDTH_B = 36; // Write data width on port B (1-36)
+  parameter READ_WIDTH_B = 	36; // Read data width on port B (1-36)
 
 	//Local_RAM
   localparam A_DATA_WRITE_WIDTH = calc_data_width(WRITE_WIDTH_A);


### PR DESCRIPTION
- Replaced **$display** with **$fatal** in **BOOT_CLOCK, DSP19x2, DSP38, FIFO18KX2, FIFO36, I_BUF, I_BUF_DS, I_DELAY, I_SERDES, O_BUFT, O_BUFT_DS,  O_DELAY, O_SERDES, O_SERDES_CLK, PLL, SOC_FPGA_TEMPERATURE, TDP_RAM18KX2 and TDP_RAM36K.**

- **TDP_RAM18KX2** and **TDP_RAM36K** model + tb updated.

- Simulation Tb added for **I_FAB** and **O_FAB**.

- Release tb added for **SOC_FPGA_INTF_AHB_M** and **SOC_FPGA_INTF_AHB_S**.

- Added Timesclae in **BOOT_CLOCK** tb.